### PR TITLE
changes to support lithops backend

### DIFF
--- a/include/hotrod-facade.h
+++ b/include/hotrod-facade.h
@@ -1,15 +1,18 @@
 #include <vector>
 #include <string>
+#include <memory>
 
 namespace infinispan {
 namespace hotrod {
 class RemoteCacheManager;
 template <class K, class V> class RemoteCache;
 class ConfigurationBuilder;
+class RemoteCacheManagerAdmin;
 }
 }
 namespace Infinispan {
 
+class RemoteCacheManagerAdmin;
 class RemoteCacheManager;
 class RemoteCache;
 
@@ -26,6 +29,7 @@ private:
     infinispan::hotrod::ConfigurationBuilder* builder;
     std::string userCpy;
     std::string passwordCpy;
+    std::string realmCpy;
 friend RemoteCacheManager;
 };
 
@@ -38,6 +42,19 @@ public:
 private:
     infinispan::hotrod::RemoteCacheManager* manager;
 friend RemoteCache;
+friend RemoteCacheManagerAdmin;
+};
+
+class RemoteCacheManagerAdmin {
+public:
+    RemoteCacheManagerAdmin(RemoteCacheManager& rcm);
+    RemoteCache createCache(const std::string name, std::string model);
+    RemoteCache createCacheWithXml(const std::string name, std::string conf);
+    RemoteCache getOrCreateCache(const std::string name, std::string model);
+    RemoteCache getOrCreateCacheWithXml(const std::string name, std::string conf);
+private:
+    RemoteCacheManager& rcm;
+    std::shared_ptr<infinispan::hotrod::RemoteCacheManagerAdmin> admin;
 };
 
 class RemoteCache {
@@ -47,13 +64,14 @@ public:
     std::vector<unsigned char>* get(const std::vector<unsigned char> &key);
     std::vector<unsigned char>* put(const std::vector<unsigned char> &key, const std::vector<unsigned char> &value);
     std::vector<unsigned char>* remove(const std::vector<unsigned char> &key);
+    std::vector<std::vector<unsigned char> > keys();
 private:
     infinispan::hotrod::RemoteCache<std::vector<unsigned char>, std::vector<unsigned char> >& cache;
 };
 
 class Util {
 public:
-	static std::string toString(std::vector<unsigned char>* u);
+	static std::string toString(std::vector<unsigned char> u);
 	static std::vector<unsigned char> fromString(std::string s);
 };
 

--- a/swig/hotswig.i
+++ b/swig/hotswig.i
@@ -1,6 +1,8 @@
 %module Infinispan
 %include "std_string.i"
 %include "std_vector.i"
+%include "std_shared_ptr.i"
+%include "cpointer.i"
 %{
 #include "hotrod-facade.h"
 %}
@@ -11,6 +13,7 @@
 %newobject Infinispan::RemoteCache::put;
 %newobject Infinispan::RemoteCache::remove;
 
-
+%pointer_functions(std::vector<unsigned char>, pvuc);
 %template(UCharVector) std::vector<unsigned char>;
+%template(UCharVectorVector) std::vector<std::vector<unsigned char> >; 
 %include "hotrod-facade.h"


### PR DESCRIPTION
this exposes the following operations:
- ADMIN create cache
- KEYS get all keys

plus:
- simplified SASL internal layer